### PR TITLE
Add visitor counter and GA4 stats update

### DIFF
--- a/.github/workflows/update-visitor-stats.yml
+++ b/.github/workflows/update-visitor-stats.yml
@@ -1,0 +1,39 @@
+name: Update Visitor Stats
+
+on:
+  schedule:
+    # Runs every day at midnight UTC
+    - cron: "0 0 * * *"
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  update-stats:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install google-analytics-data
+
+      - name: Fetch GA4 stats
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS_DATA: ${{ secrets.GOOGLE_CREDENTIALS_JSON }}
+          GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
+        run: python scripts/fetch_ga_data.py
+
+      - name: Commit and push updated stats
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/stats.json
+          git diff --staged --quiet || git commit -m "chore: update visitor stats [skip ci]"
+          git push

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -9,308 +9,1256 @@
 
 #hero:before {
   content: "";
-  background: linear-gradient(
-    135deg,
-    rgba(19, 111, 99, 0.92) 0%,
-    rgba(19, 111, 99, 0.7) 40%,
-    rgba(255, 255, 255, 0.3) 100%
-  ) !important;
+  background: linear-gradient(135deg,
+      rgba(19, 111, 99, 0.92) 0%,
+      rgba(19, 111, 99, 0.7) 40%,
+      rgba(255, 255, 255, 0.3) 100%) !important;
   position: absolute;
-  top: 0; left: 0; right: 0; bottom: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 }
 
-#hero h1 { color: #fff !important; font-size: 72px; font-weight: 800; line-height: 1.1; letter-spacing: -1px; }
-.hero-content { position: relative; z-index: 2; }
-.hero-greeting { color: rgba(255,255,255,0.8); font-size: 18px; font-family: "Poppins", sans-serif; margin-bottom: 8px; letter-spacing: 2px; text-transform: uppercase; }
-.hero-tagline { color: rgba(255,255,255,0.9); font-size: 20px; max-width: 550px; line-height: 1.6; margin-top: 16px; }
-.hero-typed { color: rgba(255,255,255,0.7); font-size: 15px; margin-top: 10px; }
-.hero-typed .typed-label { margin-right: 4px; }
-#hero p span.typed { color: #fff !important; font-weight: 600; }
+#hero h1 {
+  color: #fff !important;
+  font-size: 72px;
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -1px;
+}
 
-.hero-actions { display: flex; align-items: center; gap: 24px; margin-top: 32px; flex-wrap: wrap; }
+.hero-content {
+  position: relative;
+  z-index: 2;
+}
+
+.hero-greeting {
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 18px;
+  font-family: "Poppins", sans-serif;
+  margin-bottom: 8px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+}
+
+.hero-tagline {
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 20px;
+  max-width: 550px;
+  line-height: 1.6;
+  margin-top: 16px;
+}
+
+.hero-typed {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 15px;
+  margin-top: 10px;
+}
+
+.hero-typed .typed-label {
+  margin-right: 4px;
+}
+
+#hero p span.typed {
+  color: #fff !important;
+  font-weight: 600;
+}
+
+.hero-actions {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin-top: 32px;
+  flex-wrap: wrap;
+}
 
 .btn-cta {
-  display: inline-flex; align-items: center; gap: 8px;
-  background: #fff; color: #136f63;
-  padding: 14px 32px; border-radius: 50px;
-  font-weight: 700; font-size: 16px; font-family: "Poppins", sans-serif;
-  transition: all 0.3s ease; text-decoration: none;
-  box-shadow: 0 4px 20px rgba(0,0,0,0.15);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: #fff;
+  color: #136f63;
+  padding: 14px 32px;
+  border-radius: 50px;
+  font-weight: 700;
+  font-size: 16px;
+  font-family: "Poppins", sans-serif;
+  transition: all 0.3s ease;
+  text-decoration: none;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
 }
-.btn-cta:hover { background: #22aaa1; color: #fff; transform: translateY(-2px); box-shadow: 0 8px 30px rgba(34,170,161,0.4); }
-.btn-cta i { font-size: 22px; }
 
-#hero .social-links { margin-top: 0; }
-#hero .social-links a { color: rgba(255,255,255,0.7); font-size: 20px; margin-right: 16px; }
-#hero .social-links a:hover { color: #fff; }
+.btn-cta:hover {
+  background: #22aaa1;
+  color: #fff;
+  transform: translateY(-2px);
+  box-shadow: 0 8px 30px rgba(34, 170, 161, 0.4);
+}
+
+.btn-cta i {
+  font-size: 22px;
+}
+
+#hero .social-links {
+  margin-top: 0;
+}
+
+#hero .social-links a {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 20px;
+  margin-right: 16px;
+}
+
+#hero .social-links a:hover {
+  color: #fff;
+}
 
 @media (max-width: 992px) {
-  #hero h1 { font-size: 42px; }
-  .hero-tagline { font-size: 17px; }
-  .hero-actions { justify-content: center; }
+  #hero h1 {
+    font-size: 42px;
+  }
+
+  .hero-tagline {
+    font-size: 17px;
+  }
+
+  .hero-actions {
+    justify-content: center;
+  }
 }
+
 @media (max-width: 576px) {
-  #hero h1 { font-size: 34px; }
+  #hero h1 {
+    font-size: 34px;
+  }
 }
 
 /*--------------------------------------------------------------
 # Section General
 --------------------------------------------------------------*/
-.section-title { text-align: center; margin-bottom: 30px; }
-.section-title h2 {
-  position: relative; display: inline-block;
-  font-size: 28px; font-weight: bold; color: #136f63;
+.section-title {
+  text-align: center;
+  margin-bottom: 30px;
 }
+
+.section-title h2 {
+  position: relative;
+  display: inline-block;
+  font-size: 28px;
+  font-weight: bold;
+  color: #136f63;
+}
+
 .section-title h2::before,
 .section-title h2::after {
-  content: ""; position: absolute; height: 2px; width: 200px;
-  background-color: #136f63; top: 50%; transform: translateY(-50%);
+  content: "";
+  position: absolute;
+  height: 2px;
+  width: 200px;
+  background-color: #136f63;
+  top: 50%;
+  transform: translateY(-50%);
 }
-.section-title h2::before { left: -325px; }
-.section-title h2::after { right: -325px; }
+
+.section-title h2::before {
+  left: -325px;
+}
+
+.section-title h2::after {
+  right: -325px;
+}
+
 @media (max-width: 450px) {
-  .section-title h2::before { left: -250px !important; }
-  .section-title h2::after { right: -250px !important; }
+  .section-title h2::before {
+    left: -250px !important;
+  }
+
+  .section-title h2::after {
+    right: -250px !important;
+  }
 }
-.section-subtitle { color: #666; font-size: 16px; max-width: 500px; margin: 15px auto 0; }
+
+.section-subtitle {
+  color: #666;
+  font-size: 16px;
+  max-width: 500px;
+  margin: 15px auto 0;
+}
 
 /*--------------------------------------------------------------
 # Featured Work — Case Study Cards
 --------------------------------------------------------------*/
-.featured-work { padding: 80px 0; background: #fff; }
+.featured-work {
+  padding: 80px 0;
+  background: #fff;
+}
 
-.case-studies { display: flex; flex-direction: column; gap: 60px; }
+.case-studies {
+  display: flex;
+  flex-direction: column;
+  gap: 60px;
+}
 
 .case-study-card {
-  display: grid; grid-template-columns: 1fr 1fr; gap: 40px;
-  align-items: center; background: #fff;
-  border-radius: 16px; overflow: hidden;
-  box-shadow: 0 8px 40px rgba(0,0,0,0.08);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 40px;
+  align-items: center;
+  background: #fff;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.08);
   transition: all 0.4s ease;
 }
-.case-study-card:hover { box-shadow: 0 16px 60px rgba(19,111,99,0.15); transform: translateY(-4px); }
-.case-study-card.reversed { direction: rtl; }
-.case-study-card.reversed > * { direction: ltr; }
 
-.case-study-image { position: relative; overflow: hidden; aspect-ratio: 16/10; }
-.case-study-image img { width: 100%; height: 100%; object-fit: cover; transition: transform 0.5s ease; }
-.case-study-card:hover .case-study-image img { transform: scale(1.05); }
-.case-study-image-overlay {
-  position: absolute; inset: 0;
-  background: rgba(19,111,99,0.0); transition: all 0.3s ease;
-  display: flex; align-items: center; justify-content: center;
+.case-study-card:hover {
+  box-shadow: 0 16px 60px rgba(19, 111, 99, 0.15);
+  transform: translateY(-4px);
 }
-.case-study-image-overlay i { color: #fff; font-size: 36px; opacity: 0; transform: translateY(10px); transition: all 0.3s ease; }
-.case-study-card:hover .case-study-image-overlay { background: rgba(19,111,99,0.3); }
-.case-study-card:hover .case-study-image-overlay i { opacity: 1; transform: translateY(0); }
 
-.case-study-info { padding: 40px; }
+.case-study-card.reversed {
+  direction: rtl;
+}
+
+.case-study-card.reversed>* {
+  direction: ltr;
+}
+
+.case-study-image {
+  position: relative;
+  overflow: hidden;
+  aspect-ratio: 16/10;
+}
+
+.case-study-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.5s ease;
+}
+
+.case-study-card:hover .case-study-image img {
+  transform: scale(1.05);
+}
+
+.case-study-image-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(19, 111, 99, 0.0);
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.case-study-image-overlay i {
+  color: #fff;
+  font-size: 36px;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: all 0.3s ease;
+}
+
+.case-study-card:hover .case-study-image-overlay {
+  background: rgba(19, 111, 99, 0.3);
+}
+
+.case-study-card:hover .case-study-image-overlay i {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.case-study-info {
+  padding: 40px;
+}
 
 .case-study-role {
-  display: inline-block; font-size: 12px; font-weight: 600;
-  text-transform: uppercase; letter-spacing: 2px; color: #22aaa1;
-  background: rgba(34,170,161,0.1); padding: 4px 14px; border-radius: 20px;
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: #22aaa1;
+  background: rgba(34, 170, 161, 0.1);
+  padding: 4px 14px;
+  border-radius: 20px;
   margin-bottom: 12px;
 }
 
-.case-study-title { font-size: 28px; font-weight: 700; color: #2d3436; margin-bottom: 12px; line-height: 1.3; }
-.case-study-title a { color: inherit; text-decoration: none; transition: color 0.3s; }
-.case-study-title a:hover { color: #136f63; }
+.case-study-title {
+  font-size: 28px;
+  font-weight: 700;
+  color: #2d3436;
+  margin-bottom: 12px;
+  line-height: 1.3;
+}
 
-.case-study-tagline { color: #636e72; font-size: 15px; line-height: 1.6; margin-bottom: 16px; }
+.case-study-title a {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.3s;
+}
 
-.case-study-tools { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; }
+.case-study-title a:hover {
+  color: #136f63;
+}
+
+.case-study-tagline {
+  color: #636e72;
+  font-size: 15px;
+  line-height: 1.6;
+  margin-bottom: 16px;
+}
+
+.case-study-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
 .tool-tag {
-  background: #f0f0f0; color: #45505b; padding: 4px 12px;
-  border-radius: 20px; font-size: 11px; font-weight: 500;
+  background: #f0f0f0;
+  color: #45505b;
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 500;
   transition: all 0.3s;
 }
-.tool-tag:hover { background: #22aaa1; color: #fff; }
 
-.case-study-meta { display: flex; flex-wrap: wrap; gap: 16px; margin-bottom: 20px; font-size: 13px; color: #636e72; }
-.case-study-meta i { margin-right: 4px; }
-.case-study-link { color: #22aaa1; text-decoration: none; font-weight: 500; }
-.case-study-link:hover { color: #136f63; }
+.tool-tag:hover {
+  background: #22aaa1;
+  color: #fff;
+}
+
+.case-study-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 20px;
+  font-size: 13px;
+  color: #636e72;
+}
+
+.case-study-meta i {
+  margin-right: 4px;
+}
+
+.case-study-link {
+  color: #22aaa1;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.case-study-link:hover {
+  color: #136f63;
+}
 
 .btn-case-study {
-  display: inline-flex; align-items: center; gap: 8px;
-  color: #136f63; font-weight: 600; font-size: 14px;
-  text-decoration: none; padding: 10px 24px;
-  border: 2px solid #136f63; border-radius: 50px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #136f63;
+  font-weight: 600;
+  font-size: 14px;
+  text-decoration: none;
+  padding: 10px 24px;
+  border: 2px solid #136f63;
+  border-radius: 50px;
   transition: all 0.3s;
 }
-.btn-case-study:hover { background: #136f63; color: #fff; transform: translateX(4px); }
+
+.btn-case-study:hover {
+  background: #136f63;
+  color: #fff;
+  transform: translateX(4px);
+}
 
 .btn-archive {
-  display: inline-flex; align-items: center; gap: 8px;
-  color: #636e72; font-weight: 500; font-size: 14px;
-  text-decoration: none; padding: 10px 24px;
-  border: 1px solid #ddd; border-radius: 50px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #636e72;
+  font-weight: 500;
+  font-size: 14px;
+  text-decoration: none;
+  padding: 10px 24px;
+  border: 1px solid #ddd;
+  border-radius: 50px;
   transition: all 0.3s;
 }
-.btn-archive:hover { border-color: #136f63; color: #136f63; }
-.btn-archive i { font-size: 16px; }
+
+.btn-archive:hover {
+  border-color: #136f63;
+  color: #136f63;
+}
+
+.btn-archive i {
+  font-size: 16px;
+}
 
 @media (max-width: 768px) {
-  .case-study-card { grid-template-columns: 1fr; }
-  .case-study-card.reversed { direction: ltr; }
-  .case-study-info { padding: 24px; }
-  .case-study-title { font-size: 22px; }
+  .case-study-card {
+    grid-template-columns: 1fr;
+  }
+
+  .case-study-card.reversed {
+    direction: ltr;
+  }
+
+  .case-study-info {
+    padding: 24px;
+  }
+
+  .case-study-title {
+    font-size: 22px;
+  }
 }
 
 /*--------------------------------------------------------------
 # About Section
 --------------------------------------------------------------*/
-.about { background-color: #f8f9fa; color: #45505b; overflow: hidden; }
-.about .content h3 { color: #22aaa1; font-size: 24px; font-weight: 700; margin-bottom: 16px; }
-.about .content p { font-size: 15px; line-height: 1.8; color: #636e72; margin-bottom: 12px; }
-.about-img { max-width: 320px; }
+.about {
+  background-color: #f8f9fa;
+  color: #45505b;
+  overflow: hidden;
+}
 
-.about-meta { display: flex; flex-direction: column; gap: 10px; margin-top: 20px; }
-.about-meta-item { display: flex; align-items: center; gap: 10px; font-size: 14px; color: #636e72; }
-.about-meta-item i { color: #22aaa1; font-size: 16px; }
-.about-meta-item a { color: #22aaa1; text-decoration: none; }
-.about-meta-item a:hover { color: #136f63; }
+.about .content h3 {
+  color: #22aaa1;
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 16px;
+}
 
-#profile-transparent:hover { animation: slight-moveUpDown 2s; }
+.about .content p {
+  font-size: 15px;
+  line-height: 1.8;
+  color: #636e72;
+  margin-bottom: 12px;
+}
+
+.about-img {
+  max-width: 320px;
+}
+
+.about-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.about-meta-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  color: #636e72;
+}
+
+.about-meta-item i {
+  color: #22aaa1;
+  font-size: 16px;
+}
+
+.about-meta-item a {
+  color: #22aaa1;
+  text-decoration: none;
+}
+
+.about-meta-item a:hover {
+  color: #136f63;
+}
+
+#profile-transparent:hover {
+  animation: slight-moveUpDown 2s;
+}
 
 /*--------------------------------------------------------------
 # Animated Shapes
 --------------------------------------------------------------*/
-@keyframes slide { 0% { transform: translateX(-100%); } 50% { transform: translateX(50%) translateY(-50px) rotate(45deg); } 100% { transform: translateX(100%) translateY(0) rotate(0deg); } }
-@keyframes jump { 0%,20%,50%,80%,100% { transform: translateY(0); } 40% { transform: translateY(-30px); } 60% { transform: translateY(-15px); } }
-@keyframes rotate { 0% { transform: rotate(0deg); } 50% { transform: rotate(180deg); } 100% { transform: rotate(360deg); } }
-@keyframes moveUpDown { 0%,100% { transform: translate(60px, 0px); } 50% { transform: translate(0px, -60px); } }
-@keyframes slight-moveUpDown { 0%,100% { transform: translateY(0px); } 50% { transform: translateY(-5px); } }
+@keyframes slide {
+  0% {
+    transform: translateX(-100%);
+  }
 
-.square { width: 300px; height: 300px; top: -10px; background-color: #0563bb2d; filter: blur(25px); position: absolute; rotate: 45deg; animation: rotate 15s infinite; }
-.square1 { width: 500px; height: 500px; top: 0; right: 150px; border: 2px solid #0563bb2d; filter: blur(5px); position: absolute; rotate: 45deg; animation: rotate 15s infinite; }
-.square2 { background-color: rgba(19, 111, 99, 0.2); position: relative; top: 400px; right: 50px; width: 50px; height: 50px; z-index: -1; rotate: 45deg; animation: rotate 15s infinite; backdrop-filter: blur(10px); border: 1px solid rgba(255,255,255,0.3); box-shadow: 0 4px 8px rgba(0,0,0,0.2); }
-.square3 { background-color: #22aaa1; position: absolute; top: 70%; right: 150px; width: 100px; height: 100px; z-index: -1; rotate: 45deg; animation: moveUpDown 15s infinite; }
-.square3 img { rotate: -45deg; }
-.square4 { background-color: rgba(19, 111, 99, 0.2); position: absolute; top: 83%; right: 100px; width: 50px; height: 50px; z-index: -1; rotate: 45deg; animation: moveUpDown 15s infinite; backdrop-filter: blur(5px); border: 1px solid rgba(255,255,255,0.3); box-shadow: 0 4px 8px rgba(0,0,0,0.2); }
-.square5 { background-color: rgba(19, 111, 99, 0.2); position: absolute; top: 83%; right: 250px; width: 50px; height: 50px; z-index: -1; rotate: 45deg; animation: moveUpDown 15s infinite; backdrop-filter: blur(5px); border: 1px solid rgba(255,255,255,0.3); box-shadow: 0 4px 8px rgba(0,0,0,0.2); }
+  50% {
+    transform: translateX(50%) translateY(-50px) rotate(45deg);
+  }
+
+  100% {
+    transform: translateX(100%) translateY(0) rotate(0deg);
+  }
+}
+
+@keyframes jump {
+
+  0%,
+  20%,
+  50%,
+  80%,
+  100% {
+    transform: translateY(0);
+  }
+
+  40% {
+    transform: translateY(-30px);
+  }
+
+  60% {
+    transform: translateY(-15px);
+  }
+}
+
+@keyframes rotate {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  50% {
+    transform: rotate(180deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes moveUpDown {
+
+  0%,
+  100% {
+    transform: translate(60px, 0px);
+  }
+
+  50% {
+    transform: translate(0px, -60px);
+  }
+}
+
+@keyframes slight-moveUpDown {
+
+  0%,
+  100% {
+    transform: translateY(0px);
+  }
+
+  50% {
+    transform: translateY(-5px);
+  }
+}
+
+.square {
+  width: 300px;
+  height: 300px;
+  top: -10px;
+  background-color: #0563bb2d;
+  filter: blur(25px);
+  position: absolute;
+  rotate: 45deg;
+  animation: rotate 15s infinite;
+}
+
+.square1 {
+  width: 500px;
+  height: 500px;
+  top: 0;
+  right: 150px;
+  border: 2px solid #0563bb2d;
+  filter: blur(5px);
+  position: absolute;
+  rotate: 45deg;
+  animation: rotate 15s infinite;
+}
+
+.square2 {
+  background-color: rgba(19, 111, 99, 0.2);
+  position: relative;
+  top: 400px;
+  right: 50px;
+  width: 50px;
+  height: 50px;
+  z-index: -1;
+  rotate: 45deg;
+  animation: rotate 15s infinite;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.square3 {
+  background-color: #22aaa1;
+  position: absolute;
+  top: 70%;
+  right: 150px;
+  width: 100px;
+  height: 100px;
+  z-index: -1;
+  rotate: 45deg;
+  animation: moveUpDown 15s infinite;
+}
+
+.square3 img {
+  rotate: -45deg;
+}
+
+.square4 {
+  background-color: rgba(19, 111, 99, 0.2);
+  position: absolute;
+  top: 83%;
+  right: 100px;
+  width: 50px;
+  height: 50px;
+  z-index: -1;
+  rotate: 45deg;
+  animation: moveUpDown 15s infinite;
+  backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.square5 {
+  background-color: rgba(19, 111, 99, 0.2);
+  position: absolute;
+  top: 83%;
+  right: 250px;
+  width: 50px;
+  height: 50px;
+  z-index: -1;
+  rotate: 45deg;
+  animation: moveUpDown 15s infinite;
+  backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
 
 /*--------------------------------------------------------------
 # PreLoader
 --------------------------------------------------------------*/
-#preloader { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: #ffffff00; display: flex; justify-content: center; align-items: center; z-index: 1000; }
-#preloader:before { content: ""; box-sizing: border-box; width: 50px; height: 50px; border: 4px solid #136f63; animation: animate-preloader 1s linear infinite; }
-@keyframes animate-preloader { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+#preloader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #ffffff00;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+#preloader:before {
+  content: "";
+  box-sizing: border-box;
+  width: 50px;
+  height: 50px;
+  border: 4px solid #136f63;
+  animation: animate-preloader 1s linear infinite;
+}
+
+@keyframes animate-preloader {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
 
 /*--------------------------------------------------------------
 # Mobile Navigation
 --------------------------------------------------------------*/
-#header1 { position: fixed; bottom: 0; left: 0; padding: 15px; overflow-y: auto; z-index: 9997; }
-.nav-menu1 { padding: 0; display: flex; align-items: center; justify-content: center; overflow: hidden; }
-.nav-menu1 * { margin: 0; padding: 0; list-style: none; }
-.nav-menu1 > ul > li { float: left; position: relative; white-space: nowrap; margin-right: 8px; }
-.nav-menu1 a, .nav-menu1 a:focus { display: flex; align-items: center; color: #136f63; padding: 10px 18px; transition: 0.3s; font-size: 15px; background: #e0e0e0; border-bottom: 5px solid #136f63; border-top-right-radius: 15px; border-top-left-radius: 15px; height: 56px; width: 100%; overflow: hidden; }
-@media (max-width: 425px) { .nav-menu1 a, .nav-menu1 a:focus { padding: 5px 10px; } }
-.nav-menu1 a i, .nav-menu1 a:focus i { font-size: 20px; position: relative; align-self: center; }
-.nav-menu1 a span, .nav-menu1 a:focus span { padding: 0 5px 0 7px; color: #45505b; }
-.nav-menu1 a:hover, .nav-menu1 .active, .nav-menu1 .active:focus, .nav-menu1 li:hover > a { color: #fff; background: #136f63; }
-.nav-menu1 a:hover span, .nav-menu1 .active span, .nav-menu1 .active:focus span, .nav-menu1 li:hover > a span { color: #fff; }
+#header1 {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  padding: 15px;
+  overflow-y: auto;
+  z-index: 9997;
+}
+
+.nav-menu1 {
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.nav-menu1 * {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.nav-menu1>ul>li {
+  float: left;
+  position: relative;
+  white-space: nowrap;
+  margin-right: 8px;
+}
+
+.nav-menu1 a,
+.nav-menu1 a:focus {
+  display: flex;
+  align-items: center;
+  color: #136f63;
+  padding: 10px 18px;
+  transition: 0.3s;
+  font-size: 15px;
+  background: #e0e0e0;
+  border-bottom: 5px solid #136f63;
+  border-top-right-radius: 15px;
+  border-top-left-radius: 15px;
+  height: 56px;
+  width: 100%;
+  overflow: hidden;
+}
+
+@media (max-width: 425px) {
+
+  .nav-menu1 a,
+  .nav-menu1 a:focus {
+    padding: 5px 10px;
+  }
+}
+
+.nav-menu1 a i,
+.nav-menu1 a:focus i {
+  font-size: 20px;
+  position: relative;
+  align-self: center;
+}
+
+.nav-menu1 a span,
+.nav-menu1 a:focus span {
+  padding: 0 5px 0 7px;
+  color: #45505b;
+}
+
+.nav-menu1 a:hover,
+.nav-menu1 .active,
+.nav-menu1 .active:focus,
+.nav-menu1 li:hover>a {
+  color: #fff;
+  background: #136f63;
+}
+
+.nav-menu1 a:hover span,
+.nav-menu1 .active span,
+.nav-menu1 .active:focus span,
+.nav-menu1 li:hover>a span {
+  color: #fff;
+}
 
 /*--------------------------------------------------------------
 # Case Study Page
 --------------------------------------------------------------*/
 .back-nav {
-  position: fixed; top: 20px; left: 20px; z-index: 9999;
-  display: flex; align-items: center; gap: 8px;
-  background: rgba(255,255,255,0.95); color: #136f63;
-  padding: 10px 20px; border-radius: 50px;
-  font-weight: 600; font-size: 14px; text-decoration: none;
-  box-shadow: 0 4px 20px rgba(0,0,0,0.1);
-  transition: all 0.3s; backdrop-filter: blur(10px);
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.95);
+  color: #136f63;
+  padding: 10px 20px;
+  border-radius: 50px;
+  font-weight: 600;
+  font-size: 14px;
+  text-decoration: none;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s;
+  backdrop-filter: blur(10px);
 }
-.back-nav:hover { background: #136f63; color: #fff; transform: translateX(-4px); }
-.back-nav i { font-size: 18px; }
 
-.case-study-main { margin-left: 0 !important; }
+.back-nav:hover {
+  background: #136f63;
+  color: #fff;
+  transform: translateX(-4px);
+}
 
-.cs-hero { position: relative; height: 60vh; min-height: 400px; display: flex; align-items: flex-end; overflow: hidden; }
-.cs-hero-image { position: absolute; inset: 0; background-size: cover; background-position: center top; }
-.cs-hero-overlay { position: absolute; inset: 0; background: linear-gradient(to top, rgba(0,0,0,0.8) 0%, rgba(0,0,0,0.2) 50%, rgba(0,0,0,0) 100%); }
-.cs-hero-content { position: relative; z-index: 2; padding-bottom: 60px; color: #fff; }
-.cs-hero-role { display: inline-block; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 2px; background: rgba(34,170,161,0.8); padding: 4px 14px; border-radius: 20px; margin-bottom: 12px; }
-.cs-hero-title { font-size: 48px; font-weight: 800; line-height: 1.2; margin-bottom: 12px; }
-.cs-hero-tagline { font-size: 18px; opacity: 0.85; max-width: 600px; }
+.back-nav i {
+  font-size: 18px;
+}
+
+.case-study-main {
+  margin-left: 0 !important;
+}
+
+.cs-hero {
+  position: relative;
+  height: 60vh;
+  min-height: 400px;
+  display: flex;
+  align-items: flex-end;
+  overflow: hidden;
+}
+
+.cs-hero-image {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center top;
+}
+
+.cs-hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.2) 50%, rgba(0, 0, 0, 0) 100%);
+}
+
+.cs-hero-content {
+  position: relative;
+  z-index: 2;
+  padding-bottom: 60px;
+  color: #fff;
+}
+
+.cs-hero-role {
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  background: rgba(34, 170, 161, 0.8);
+  padding: 4px 14px;
+  border-radius: 20px;
+  margin-bottom: 12px;
+}
+
+.cs-hero-title {
+  font-size: 48px;
+  font-weight: 800;
+  line-height: 1.2;
+  margin-bottom: 12px;
+}
+
+.cs-hero-tagline {
+  font-size: 18px;
+  opacity: 0.85;
+  max-width: 600px;
+}
 
 @media (max-width: 768px) {
-  .cs-hero { height: 50vh; min-height: 300px; }
-  .cs-hero-title { font-size: 32px; }
-  .cs-hero-content { padding-bottom: 40px; }
+  .cs-hero {
+    height: 50vh;
+    min-height: 300px;
+  }
+
+  .cs-hero-title {
+    font-size: 32px;
+  }
+
+  .cs-hero-content {
+    padding-bottom: 40px;
+  }
 }
 
-.cs-meta { background: #f8f9fa; padding: 40px 0; border-bottom: 1px solid #eee; }
-.cs-meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 24px; }
-.cs-meta-item { display: flex; flex-direction: column; gap: 4px; }
-.cs-meta-label { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 1.5px; color: #22aaa1; }
-.cs-meta-value { font-size: 14px; color: #45505b; }
-.cs-meta-value a { color: #22aaa1; text-decoration: none; }
-.cs-meta-value a:hover { color: #136f63; text-decoration: underline; }
+.cs-meta {
+  background: #f8f9fa;
+  padding: 40px 0;
+  border-bottom: 1px solid #eee;
+}
 
-.cs-body { padding: 60px 0; }
-.cs-story { max-width: 720px; margin: 0 auto; }
-.cs-story-block { margin-bottom: 48px; }
-.cs-section-title { font-size: 22px; font-weight: 700; color: #136f63; margin-bottom: 16px; position: relative; padding-bottom: 10px; }
-.cs-section-title::after { content: ""; position: absolute; bottom: 0; left: 0; width: 40px; height: 3px; background: #22aaa1; border-radius: 2px; }
-.cs-story-block p { font-size: 16px; line-height: 1.8; color: #636e72; }
+.cs-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 24px;
+}
 
-.cs-gallery { padding: 60px 0; background: #f8f9fa; }
-.cs-gallery .cs-section-title { text-align: center; }
-.cs-gallery .cs-section-title::after { left: 50%; transform: translateX(-50%); }
-.cs-gallery-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px; margin-top: 32px; }
-.cs-gallery-item { position: relative; border-radius: 12px; overflow: hidden; cursor: pointer; aspect-ratio: 16/10; }
-.cs-gallery-item img { width: 100%; height: 100%; object-fit: cover; transition: transform 0.4s; }
-.cs-gallery-item:hover img { transform: scale(1.05); }
-.cs-gallery-caption { position: absolute; bottom: 0; left: 0; right: 0; padding: 12px 16px; background: linear-gradient(to top, rgba(0,0,0,0.7), transparent); color: #fff; font-size: 13px; font-weight: 500; opacity: 0; transition: opacity 0.3s; }
-.cs-gallery-item:hover .cs-gallery-caption { opacity: 1; }
+.cs-meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
 
-.cs-takeaways { padding: 60px 0; }
-.cs-takeaways .cs-section-title { text-align: center; }
-.cs-takeaways .cs-section-title::after { left: 50%; transform: translateX(-50%); }
-.cs-takeaways-list { list-style: none; padding: 0; max-width: 600px; margin: 32px auto 0; }
-.cs-takeaways-list li { display: flex; align-items: flex-start; gap: 12px; padding: 12px 0; font-size: 15px; color: #45505b; border-bottom: 1px solid #f0f0f0; }
-.cs-takeaways-list li i { color: #22aaa1; font-size: 18px; margin-top: 2px; flex-shrink: 0; }
+.cs-meta-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: #22aaa1;
+}
 
-.cs-navigation { padding: 40px 0; border-top: 1px solid #eee; }
-.cs-nav-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
-.cs-nav-item { display: flex; flex-direction: column; gap: 4px; padding: 20px; background: #f8f9fa; border-radius: 12px; text-decoration: none; transition: all 0.3s; }
-.cs-nav-item:hover { background: #136f63; }
-.cs-nav-item:hover .cs-nav-label, .cs-nav-item:hover .cs-nav-title { color: #fff; }
-.cs-nav-next { text-align: right; }
-.cs-nav-label { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px; color: #22aaa1; }
-.cs-nav-title { font-size: 16px; font-weight: 700; color: #2d3436; }
+.cs-meta-value {
+  font-size: 14px;
+  color: #45505b;
+}
+
+.cs-meta-value a {
+  color: #22aaa1;
+  text-decoration: none;
+}
+
+.cs-meta-value a:hover {
+  color: #136f63;
+  text-decoration: underline;
+}
+
+.cs-body {
+  padding: 60px 0;
+}
+
+.cs-story {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.cs-story-block {
+  margin-bottom: 48px;
+}
+
+.cs-section-title {
+  font-size: 22px;
+  font-weight: 700;
+  color: #136f63;
+  margin-bottom: 16px;
+  position: relative;
+  padding-bottom: 10px;
+}
+
+.cs-section-title::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 40px;
+  height: 3px;
+  background: #22aaa1;
+  border-radius: 2px;
+}
+
+.cs-story-block p {
+  font-size: 16px;
+  line-height: 1.8;
+  color: #636e72;
+}
+
+.cs-gallery {
+  padding: 60px 0;
+  background: #f8f9fa;
+}
+
+.cs-gallery .cs-section-title {
+  text-align: center;
+}
+
+.cs-gallery .cs-section-title::after {
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.cs-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+  margin-top: 32px;
+}
+
+.cs-gallery-item {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: pointer;
+  aspect-ratio: 16/10;
+}
+
+.cs-gallery-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.4s;
+}
+
+.cs-gallery-item:hover img {
+  transform: scale(1.05);
+}
+
+.cs-gallery-caption {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 12px 16px;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 500;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.cs-gallery-item:hover .cs-gallery-caption {
+  opacity: 1;
+}
+
+.cs-takeaways {
+  padding: 60px 0;
+}
+
+.cs-takeaways .cs-section-title {
+  text-align: center;
+}
+
+.cs-takeaways .cs-section-title::after {
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.cs-takeaways-list {
+  list-style: none;
+  padding: 0;
+  max-width: 600px;
+  margin: 32px auto 0;
+}
+
+.cs-takeaways-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 0;
+  font-size: 15px;
+  color: #45505b;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.cs-takeaways-list li i {
+  color: #22aaa1;
+  font-size: 18px;
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+
+.cs-navigation {
+  padding: 40px 0;
+  border-top: 1px solid #eee;
+}
+
+.cs-nav-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+.cs-nav-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 20px;
+  background: #f8f9fa;
+  border-radius: 12px;
+  text-decoration: none;
+  transition: all 0.3s;
+}
+
+.cs-nav-item:hover {
+  background: #136f63;
+}
+
+.cs-nav-item:hover .cs-nav-label,
+.cs-nav-item:hover .cs-nav-title {
+  color: #fff;
+}
+
+.cs-nav-next {
+  text-align: right;
+}
+
+.cs-nav-label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: #22aaa1;
+}
+
+.cs-nav-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #2d3436;
+}
 
 @media (max-width: 576px) {
-  .cs-nav-grid { grid-template-columns: 1fr; }
+  .cs-nav-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /*--------------------------------------------------------------
 # Archive Page
 --------------------------------------------------------------*/
-.archive-main { margin-left: 0 !important; }
-.archive-header { padding: 100px 0 40px; text-align: center; background: linear-gradient(135deg, #136f63, #22aaa1); color: #fff; }
-.archive-header h1 { font-size: 42px; font-weight: 800; margin-bottom: 12px; }
-.archive-header p { font-size: 16px; opacity: 0.85; max-width: 500px; margin: 0 auto; }
+.archive-main {
+  margin-left: 0 !important;
+}
+
+.archive-header {
+  padding: 100px 0 40px;
+  text-align: center;
+  background: linear-gradient(135deg, #136f63, #22aaa1);
+  color: #fff;
+}
+
+.archive-header h1 {
+  font-size: 42px;
+  font-weight: 800;
+  margin-bottom: 12px;
+}
+
+.archive-header p {
+  font-size: 16px;
+  opacity: 0.85;
+  max-width: 500px;
+  margin: 0 auto;
+}
 
 /*--------------------------------------------------------------
 # Facts & CountBox (kept for archive compatibility)
 --------------------------------------------------------------*/
-.facts .count-box { background-color: #eeeeee !important; border-radius: 15px !important; }
-.facts .count-box i { position: relative !important; width: 0 !important; height: 0 !important; color: #0563bb !important; top: 0 !important; left: 0 !important; font-size: 30px; }
-.facts .count-box p { font-size: 16px; font-weight: bold; }
+.facts .count-box {
+  background-color: #eeeeee !important;
+  border-radius: 15px !important;
+}
+
+.facts .count-box i {
+  position: relative !important;
+  width: 0 !important;
+  height: 0 !important;
+  color: #0563bb !important;
+  top: 0 !important;
+  left: 0 !important;
+  font-size: 30px;
+}
+
+.facts .count-box p {
+  font-size: 16px;
+  font-weight: bold;
+}
 
 /*--------------------------------------------------------------
 # Category Tags
 --------------------------------------------------------------*/
-.category-tag { background-color: #f5f5f5; color: #45505b; float: left; margin: 5px; padding: 5px 15px; border-radius: 20px; font-size: 10px; text-decoration: none; transition: background-color 0.3s ease; }
-.category-tag:hover { animation: slight-moveUpDown 0.75s; }
+.category-tag {
+  background-color: #f5f5f5;
+  color: #45505b;
+  float: left;
+  margin: 5px;
+  padding: 5px 15px;
+  border-radius: 20px;
+  font-size: 10px;
+  text-decoration: none;
+  transition: background-color 0.3s ease;
+}
+
+.category-tag:hover {
+  animation: slight-moveUpDown 0.75s;
+}
 
 /*--------------------------------------------------------------
 # GLightbox Custom
 --------------------------------------------------------------*/
-.gclose-custom { position: fixed; top: 20px; right: 30px; z-index: 1000001; background: rgba(0,0,0,0.7); border: 2px solid #fff; border-radius: 50%; width: 50px; height: 50px; display: flex; align-items: center; justify-content: center; cursor: pointer; transition: all 0.3s ease; color: #fff; font-size: 28px; box-shadow: 0 4px 10px rgba(0,0,0,0.3); }
-.gclose-custom:hover { background: #0563bb; border-color: #0563bb; transform: scale(1.1); }
+.gclose-custom {
+  position: fixed;
+  top: 20px;
+  right: 30px;
+  z-index: 1000001;
+  background: rgba(0, 0, 0, 0.7);
+  border: 2px solid #fff;
+  border-radius: 50%;
+  width: 50px;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  color: #fff;
+  font-size: 28px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
+
+.gclose-custom:hover {
+  background: #0563bb;
+  border-color: #0563bb;
+  transform: scale(1.1);
+}
+
+/* ===========================
+   Visitor Counter
+   =========================== */
+.visitor-counter {
+  margin: 25px 0 15px;
+  display: flex;
+  justify-content: center;
+}
+
+.visitor-counter-inner {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 24px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 50px;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  transition: all 0.3s ease;
+}
+
+.visitor-counter-inner:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.2);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+}
+
+.visitor-counter-icon {
+  font-size: 1.3rem;
+  color: #149ddd;
+  opacity: 0.9;
+}
+
+.visitor-counter-content {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.visitor-count-number {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #f5f5f5;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.5px;
+}
+
+.visitor-count-label {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.55);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: 500;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .visitor-counter-inner {
+    padding: 10px 20px;
+    gap: 10px;
+  }
+
+  .visitor-count-number {
+    font-size: 1.2rem;
+  }
+
+  .visitor-count-label {
+    font-size: 0.7rem;
+  }
+}

--- a/assets/js/visitor-counter.js
+++ b/assets/js/visitor-counter.js
@@ -1,0 +1,80 @@
+/**
+ * Visitor Counter
+ * Fetches the total unique visitors from data/stats.json
+ * and renders it into the DOM with a counting animation.
+ */
+(function () {
+    "use strict";
+
+    const STATS_URL = "data/stats.json";
+    const COUNTER_SELECTOR = "#visitor-count";
+    const ANIMATION_DURATION = 2000; // ms
+
+    /**
+     * Animate counting from 0 to target number.
+     */
+    function animateCount(element, target) {
+        const start = 0;
+        const startTime = performance.now();
+
+        function update(currentTime) {
+            const elapsed = currentTime - startTime;
+            const progress = Math.min(elapsed / ANIMATION_DURATION, 1);
+
+            // Ease-out cubic for a smooth deceleration
+            const eased = 1 - Math.pow(1 - progress, 3);
+            const current = Math.floor(eased * (target - start) + start);
+
+            element.textContent = current.toLocaleString();
+
+            if (progress < 1) {
+                requestAnimationFrame(update);
+            } else {
+                element.textContent = target.toLocaleString();
+            }
+        }
+
+        requestAnimationFrame(update);
+    }
+
+    /**
+     * Fetch stats and display the visitor count.
+     */
+    async function init() {
+        const counterEl = document.querySelector(COUNTER_SELECTOR);
+        if (!counterEl) return;
+
+        try {
+            const response = await fetch(STATS_URL);
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+            const data = await response.json();
+            const total = data.totalUniqueVisitors || 0;
+
+            // Use Intersection Observer to trigger animation when visible
+            const observer = new IntersectionObserver(
+                (entries) => {
+                    entries.forEach((entry) => {
+                        if (entry.isIntersecting) {
+                            animateCount(counterEl, total);
+                            observer.unobserve(entry.target);
+                        }
+                    });
+                },
+                { threshold: 0.5 }
+            );
+
+            observer.observe(counterEl.closest(".visitor-counter") || counterEl);
+        } catch (error) {
+            console.warn("Visitor counter: Could not load stats.", error);
+            counterEl.textContent = "—";
+        }
+    }
+
+    // Run on DOM ready
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})();

--- a/index.html
+++ b/index.html
@@ -352,6 +352,16 @@
             class="bx bxl-linkedin"></i></a>
         <a target="_blank" href="https://github.com/srollorata" class="github"><i class="bx bxl-github"></i></a>
       </div>
+      <!-- Visitor Counter -->
+      <div class="visitor-counter" data-aos="fade-up">
+        <div class="visitor-counter-inner">
+          <i class="bi bi-people-fill visitor-counter-icon"></i>
+          <div class="visitor-counter-content">
+            <span id="visitor-count" class="visitor-count-number">—</span>
+            <span class="visitor-count-label">Unique Visitors</span>
+          </div>
+        </div>
+      </div>
       <div class="copyright">
         &copy; Copyright <strong><span>Selwyn Rollorata</span></strong>. All Rights Reserved
       </div>
@@ -385,6 +395,9 @@
 
   <!-- Featured Work Loader -->
   <script src="assets/js/featured-work.js"></script>
+
+  <!-- Visitor Counter -->
+  <script src="assets/js/visitor-counter.js"></script>
 </body>
 
 </html>

--- a/scripts/fetch_ga_data.py
+++ b/scripts/fetch_ga_data.py
@@ -1,0 +1,61 @@
+import json
+import os
+from datetime import datetime
+from google.analytics.data_v1beta import BetaAnalyticsDataClient
+from google.analytics.data_v1beta.types import (
+    RunReportRequest,
+    DateRange,
+    Metric,
+)
+
+def main():
+    # Load credentials from environment variable
+    credentials_json = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_DATA")
+    property_id = os.environ.get("GA4_PROPERTY_ID")
+
+    if not credentials_json or not property_id:
+        raise ValueError("Missing GOOGLE_APPLICATION_CREDENTIALS_DATA or GA4_PROPERTY_ID")
+
+    # Write credentials to a temp file for the client library
+    creds_path = "/tmp/ga_credentials.json"
+    with open(creds_path, "w") as f:
+        f.write(credentials_json)
+
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = creds_path
+
+    # Initialize the client
+    client = BetaAnalyticsDataClient()
+
+    # Fetch total unique users (all-time)
+    request = RunReportRequest(
+        property=f"properties/{property_id}",
+        date_ranges=[
+            DateRange(start_date="2020-01-01", end_date="today")
+        ],
+        metrics=[
+            Metric(name="totalUsers"),
+        ],
+    )
+
+    response = client.run_report(request)
+
+    # Extract the total unique users count
+    total_users = 0
+    if response.rows:
+        total_users = int(response.rows[0].metric_values[0].value)
+
+    # Build the stats object
+    stats = {
+        "totalUniqueVisitors": total_users,
+        "lastUpdated": datetime.utcnow().isoformat() + "Z",
+    }
+
+    # Write to data/stats.json
+    os.makedirs("data", exist_ok=True)
+    with open("data/stats.json", "w") as f:
+        json.dump(stats, f, indent=2)
+
+    print(f"✅ Updated stats.json: {total_users} unique visitors")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a visitor counter feature and automation to keep stats up to date. Includes a GitHub Actions workflow (.github/workflows/update-visitor-stats.yml) that runs daily (and on demand) to call scripts/fetch_ga_data.py using google-analytics-data and commits data/stats.json. Adds a frontend visitor-counter component: assets/js/visitor-counter.js (count animation) and CSS styles in assets/css/custom.css, and updates index.html to render the counter. This enables displaying live visitor totals while automating periodic GA4 data fetches using repository secrets for credentials.