### PR TITLE
Set origin URL with PAT in workflow

### DIFF
--- a/.github/workflows/update-visitor-stats.yml
+++ b/.github/workflows/update-visitor-stats.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/${{ github.repository }}
           git add data/stats.json
           git diff --staged --quiet || git commit -m "chore: update visitor stats [skip ci]"
           git push


### PR DESCRIPTION
- Update the update-visitor-stats workflow to set the origin remote URL using an x-access-token with secrets.PAT_TOKEN before pushing. This ensures the workflow can authenticate and push the committed data/stats.json to github.com/${{ github.repository }} after configuring the git user.